### PR TITLE
Update messageList.ts

### DIFF
--- a/src/content/messageList.ts
+++ b/src/content/messageList.ts
@@ -28,7 +28,7 @@ const crearteMessageListFilterer = (workspace: Workspace) => async () => {
   let isBlocked = false;
   Array.from(messageNodes).forEach(node => {
       const $div = node.querySelector('div')
-      if (!$div || !$div.classList.contains('c-message')) return;
+      if (!$div || !$div.classList.contains('c-message_kit__message')) return;
       const isAdjacent = $div.classList.contains('c-message--adjacent')
       if (!isAdjacent) {
         const userId = getUserIdFromVirtualItem(node)


### PR DESCRIPTION
Recently Slack made some changes that broke this extension's functionality (div classes of "c-message" and "c-message--adjacent" not working). After many trials and errors, I managed to fix message blocking by replacing "c-message" with "c-message_kit__message" in line 31. But As I don't have any knowledge of programming, I couldn't figure out how to fix adjacent message blocking. Without this functionality, if a blocked user posts multiple messages in a row, only the first message gets blocked. I'd appreciate it very much if you would fix it.